### PR TITLE
Update random algorithm to truncate scores and sel_ind based on top_ argument

### DIFF
--- a/dora_exp_pipeline/random_outlier_detection.py
+++ b/dora_exp_pipeline/random_outlier_detection.py
@@ -28,7 +28,7 @@ class RandomOutlierDetection(OutlierDetection):
         # the scores are sorted later they will have the
         # random order.
         scores = list(np.zeros(data_to_score.shape[0], dtype=float))
-        
+
         results = dict()
         results.setdefault('scores', list())
         results.setdefault('sel_ind', list())
@@ -39,7 +39,6 @@ class RandomOutlierDetection(OutlierDetection):
             results['dts_ids'].append(data_to_score_ids[ind])
 
         return results
-    
 
     def _rank_internal(self, data_to_fit, data_to_score, data_to_score_ids,
                        top_n, seed):


### PR DESCRIPTION
This update only affects the random algorithm, and only affects downstream results organization modules that may use the `scores` and `sel_ind` results.  Previously, these lists were not being truncated to the top N. The `dts_ids` result was already being truncated, and since it was the shortest list, it was (effectively) truncating what went into `selections.csv` already due to the `zip()` command here:
https://github.com/nasaharvest/dora/blob/8d889357e0f74dcf190deaa73951d7c207b767d2/dora_exp_pipeline/dora_results_organization.py#L77-L79
Now all three values are being truncated by the random algorithm akin to how it is done in other algorithms.