### PR TITLE
Support .csv inputs for FeatureVector data type. Closes #15

### DIFF
--- a/dora_exp_pipeline/dora_data_loader.py
+++ b/dora_exp_pipeline/dora_data_loader.py
@@ -268,7 +268,8 @@ class FeatureVectorLoader(DataLoader):
                     # Assumes the first column is the ID
                     # and all other columns are (float) feature values
                     data_dict['id'].append(row[0])
-                    data_dict['data'].append(np.array([float(v) for v in row[1:]]))
+                    data_dict['data'].append(np.array(
+                        [float(v) for v in row[1:]]))
 
         else:
             raise RuntimeError(f'File extension not supported. '


### PR DESCRIPTION
I've updated the FeatureVector loader to support `.csv` inputs.
This will close #15 (not 60 as noted in the commit message, oops!).