### PR TITLE
Added 'fit_single_trees' argument to volcanoes config files. 

### DIFF
--- a/sample_data/earth_volcanoes/exp/patches/earth_volcanoes_patches.yml
+++ b/sample_data/earth_volcanoes/exp/patches/earth_volcanoes_patches.yml
@@ -21,7 +21,8 @@ features: {
 top_n: 'None'
 outlier_detection: {
     iforest: {
-        n_trees: 100
+        n_trees: 100,
+        fit_single_trees: False
     },
     demud: {
         k: 3

--- a/sample_data/earth_volcanoes/exp/pixels/earth_volcanoes_pixels.yml
+++ b/sample_data/earth_volcanoes/exp/pixels/earth_volcanoes_pixels.yml
@@ -19,7 +19,8 @@ features: {
 top_n: 'None'
 outlier_detection: {
     iforest: {
-        n_trees: 100
+        n_trees: 100,
+        fit_single_trees: False
     },
     demud: {
         k: 1


### PR DESCRIPTION
# Description
Missing argument `fit_single_trees` in `sample_data` config files for volcano patches and pixels for Isolation forest (iForest) method.

## Bug
### Patches
**Command line**: `dora_exp sample_data/earth_volcanoes/exp/patches/earth_volcanoes_patches.yml`
**Error**: File "*/dora/.venv/lib/python3.8/site-packages/dora_exp_pipeline/outlier_detection.py", line 69, in run
    results = self._rank_internal(dtf, dts, dts_ids, top_n, seed, **kwargs)
TypeError: _rank_internal() missing 1 required positional argument: 'fit_single_trees'

### Pixels
**Command line**: `dora_exp sample_data/earth_volcanoes/exp/pixels/earth_volcanoes_pixels.yml`
**Error**: File "*/dora/.venv/lib/python3.8/site-packages/dora_exp_pipeline/outlier_detection.py", line 69, in run
    results = self._rank_internal(dtf, dts, dts_ids, top_n, seed, **kwargs)
TypeError: _rank_internal() missing 1 required positional argument: 'fit_single_trees'

# Validation
Tested on the master branch. Reproduced the results from `/*/dora/test/ref-results/earth_volcanoes_pixels/iforest-n_trees=100-fit_single_trees=False/selections-iforest.csv` and `/*/dora/test/ref-results/earth_volcanoes_patches/iforest-n_trees=100-fit_single_trees=False/selections-iforest.csv`.